### PR TITLE
Revamp to make QDateTime timestamps testable

### DIFF
--- a/zera-timers/lib/timerfactoryqt.cpp
+++ b/zera-timers/lib/timerfactoryqt.cpp
@@ -2,14 +2,9 @@
 #include "timersingleshotqt.h"
 #include "timerperiodicqt.h"
 
-std::function<TimerTemplateQtPtr(int)> TimerFactoryQt::m_singleShotCreateFunction = [](int timeout){
-    return std::make_unique<TimerSingleShotQt>(timeout);
-};
-
-std::function<TimerTemplateQtPtr(int)> TimerFactoryQt::m_periodicCreateFunction = [](int timeout){
-    return std::make_unique<TimerPeriodicQt>(timeout);
-};
-
+std::function<TimerTemplateQtPtr(int)> TimerFactoryQt::m_singleShotCreateFunction = defaultSingleShotCreateFunc();
+std::function<TimerTemplateQtPtr(int)> TimerFactoryQt::m_periodicCreateFunction = defaultPeriodicCreateFunc();
+std::function<QDateTime()> TimerFactoryQt::m_getCurrentTimeFunction = defaultGetCurrentTimeFunc();
 
 TimerTemplateQtPtr TimerFactoryQt::createSingleShot(int timeout)
 {
@@ -19,4 +14,30 @@ TimerTemplateQtPtr TimerFactoryQt::createSingleShot(int timeout)
 TimerTemplateQtPtr TimerFactoryQt::createPeriodic(int timeout)
 {
     return m_periodicCreateFunction(timeout);
+}
+
+QDateTime TimerFactoryQt::getCurrentTime()
+{
+    return m_getCurrentTimeFunction();
+}
+
+std::function<TimerTemplateQtPtr (int)> TimerFactoryQt::defaultSingleShotCreateFunc()
+{
+    return [](int timeout) {
+        return std::make_unique<TimerSingleShotQt>(timeout);
+    };
+}
+
+std::function<TimerTemplateQtPtr (int)> TimerFactoryQt::defaultPeriodicCreateFunc()
+{
+    return [](int timeout) {
+        return std::make_unique<TimerPeriodicQt>(timeout);
+    };
+}
+
+std::function<QDateTime ()> TimerFactoryQt::defaultGetCurrentTimeFunc()
+{
+    return []() {
+        return QDateTime::currentDateTime();
+    };
 }

--- a/zera-timers/lib/timerfactoryqt.h
+++ b/zera-timers/lib/timerfactoryqt.h
@@ -2,19 +2,26 @@
 #define TIMERFACTORYQT_H
 
 #include "timertemplateqt.h"
+#include <QDateTime>
 #include <functional>
 
-/* Use TimerFactoryQt to create zera-timers - otherwise tests will fail
- * (see testlib/TimerFactoryQtForTest why)
-*/
+// To make code testable, use TimerFactoryQt to
+// * create zera-timers (see testlib/TimerFactoryQtForTest why)
+// * ask for current time
 class TimerFactoryQt
 {
 public:
     static TimerTemplateQtPtr createSingleShot(int timeout);
     static TimerTemplateQtPtr createPeriodic(int timeout);
+    static QDateTime getCurrentTime();
 protected:
+    static std::function<TimerTemplateQtPtr(int)> defaultSingleShotCreateFunc();
+    static std::function<TimerTemplateQtPtr(int)> defaultPeriodicCreateFunc();
+    static std::function<QDateTime()> defaultGetCurrentTimeFunc();
+
     static std::function<TimerTemplateQtPtr(int)> m_singleShotCreateFunction;
     static std::function<TimerTemplateQtPtr(int)> m_periodicCreateFunction;
+    static std::function<QDateTime()> m_getCurrentTimeFunction;
 };
 
 #endif // TIMERFACTORYQT_H

--- a/zera-timers/testlib/timerfactoryqtfortest.cpp
+++ b/zera-timers/testlib/timerfactoryqtfortest.cpp
@@ -1,14 +1,26 @@
 #include "timerfactoryqtfortest.h"
 #include "timerfortestsingleshot.h"
 #include "timerfortestperiodic.h"
+#include "timemachinefortest.h"
 
 void TimerFactoryQtForTest::enableTest()
 {
-    m_singleShotCreateFunction = [](int timeout){
+    m_singleShotCreateFunction = [](int timeout) {
         return std::make_unique<TimerForTestSingleShot>(timeout);
     };
-
-    m_periodicCreateFunction = [](int timeout){
+    m_periodicCreateFunction = [](int timeout) {
         return std::make_unique<TimerForTestPeriodic>(timeout);
     };
+    m_getCurrentTimeFunction = []() {
+        QDateTime dtTime;
+        dtTime.setMSecsSinceEpoch(TimeMachineForTest::getInstance()->getCurrentTimeMs());
+        return dtTime;
+    };
+}
+
+void TimerFactoryQtForTest::disableTest()
+{
+    m_singleShotCreateFunction = defaultSingleShotCreateFunc();
+    m_periodicCreateFunction = defaultPeriodicCreateFunc();
+    m_getCurrentTimeFunction = defaultGetCurrentTimeFunc();
 }

--- a/zera-timers/testlib/timerfactoryqtfortest.h
+++ b/zera-timers/testlib/timerfactoryqtfortest.h
@@ -7,6 +7,7 @@ class TimerFactoryQtForTest : public TimerFactoryQt
 {
 public:
     static void enableTest();
+    static void disableTest();
 };
 
 #endif // TIMERFACTORYQTFORTEST_H

--- a/zera-timers/tests/CMakeLists.txt
+++ b/zera-timers/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 SETUP_QTESTS(
     test_timersingleshotqt
     test_timerperiodicqt
+    test_current_time
     )

--- a/zera-timers/tests/test_current_time.cpp
+++ b/zera-timers/tests/test_current_time.cpp
@@ -1,0 +1,44 @@
+#include "test_current_time.h"
+#include "timerfactoryqtfortest.h"
+#include "timemachinefortest.h"
+#include <QTest>
+
+QTEST_MAIN(test_current_time)
+
+void test_current_time::disableTest()
+{
+    TimerFactoryQtForTest::disableTest();
+
+    QDateTime dtTime1 = TimerFactoryQtForTest::getCurrentTime();
+    QTest::qSleep(10);
+    QDateTime dtTime2 = TimerFactoryQtForTest::getCurrentTime();
+    QVERIFY(dtTime2 > dtTime1);
+}
+
+void test_current_time::enableTestNoTimeProgression()
+{
+    TimerFactoryQtForTest::enableTest();
+
+    QDateTime dtTime1 = TimerFactoryQtForTest::getCurrentTime();
+    QTest::qSleep(10);
+    QDateTime dtTime2 = TimerFactoryQtForTest::getCurrentTime();
+    QCOMPARE(dtTime2, dtTime1);
+}
+
+void test_current_time::enableTestTimeProgression()
+{
+    TimerFactoryQtForTest::enableTest();
+
+    TimeMachineForTest::getInstance()->processTimers(100);
+    QDateTime dtTime1 = TimerFactoryQtForTest::getCurrentTime();
+    TimeMachineForTest::getInstance()->processTimers(150);
+    QDateTime dtTime2 = TimerFactoryQtForTest::getCurrentTime();
+
+    QDateTime dtTimeTest;
+
+    dtTimeTest.setMSecsSinceEpoch(100);
+    QCOMPARE(dtTime1, dtTimeTest);
+
+    dtTimeTest.setMSecsSinceEpoch(100+150);
+    QCOMPARE(dtTime2, dtTimeTest);
+}

--- a/zera-timers/tests/test_current_time.h
+++ b/zera-timers/tests/test_current_time.h
@@ -1,0 +1,15 @@
+#ifndef TEST_CURRENT_TIME_H
+#define TEST_CURRENT_TIME_H
+
+#include <QObject>
+
+class test_current_time : public QObject
+{
+    Q_OBJECT
+private slots:
+    void disableTest();
+    void enableTestNoTimeProgression();
+    void enableTestTimeProgression();
+};
+
+#endif // TEST_CURRENT_TIME_H


### PR DESCRIPTION
To make code testable it should replace QDateTime::currentDateTime() by TimerFactoryQt::getCurrentTime()